### PR TITLE
Update sem sd

### DIFF
--- a/Accesstra_2.0/Accesstra_2.0.ino
+++ b/Accesstra_2.0/Accesstra_2.0.ino
@@ -2,7 +2,7 @@
 //  - Marcos-Pietrucci 
 //    https://github.com/Marcos-Pietrucci/Acesstra-ADA/tree/master/codigo
 
-//*****************************************************************************************//
+//***************************************************************************************** teste de teste//
 
 #include <SPI.h>
 #include <MFRC522.h>


### PR DESCRIPTION
Nesta atualização, eu retirei todas as partes do código que tratava de cadastrar os membros com seus respectivos números. Além disso, tentei limpar o código, deixando apenas o necessário e retirando os "pints", já que está funcionando muito bem.

Conforme todos concordaram, todos os membros terão uma TAG com o mesmo número de acesso registrado, sem que haja uma forma de distinguir quem abriu ou fechou a porta